### PR TITLE
Merge pull request #23 from jonesbp/master

### DIFF
--- a/src/Scrollama.js
+++ b/src/Scrollama.js
@@ -53,10 +53,15 @@ class Scrollama extends Component {
 
   constructor(props) {
     super(props);
-    const { children, onStepEnter, onStepExit, offset, debug } = this.props;
+    const { children, prefix, onStepEnter, onStepExit, offset, debug } = this.props;
 
-    React.Children.forEach(children, () => {
-      const childId = uuidv4();
+    React.Children.forEach(children, (child, idx) => {
+      let childId;
+      if (prefix) {
+        childId = `scrollama-${prefix}-${idx}`;
+      } else {
+        childId = uuidv4();
+      }
       this[childId] = React.createRef();
       this.stepElIds.push(childId);
     });


### PR DESCRIPTION
Adding the option to specify a prefix for Step ids allows for consistently defined
Step ids for using the Scrollama component in combination with SSR.

In the absence of a value for the prefix prop, uuids will be generated for the
Step ids.