### PR TITLE
Changes prepublish to prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "rollup -c",
     "start": "rollup -c -w",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "predeploy": "cd example && npm install && npm run build",
     "deploy": "gh-pages -d example/build"
   },


### PR DESCRIPTION
This PR changes the deprecated `prepublish` run script to [the newer `prepublishOnly`](https://docs.npmjs.com/misc/scripts#deprecation-note). I think this will preserve what you want—`npm run build` should still run before `npm publish`—but it won’t run on `npm install` for people setting up the repository locally for the first time.

Thanks for the work on this component!