### PR TITLE
Simplify and modernize no frills code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,37 +34,36 @@ $ npm install react-scrollama
 A no-frills example:
 
 ```js
-import React, { Component } from 'react';
-import { Scrollama, Step } from 'react-scrollama';
+import React, {useState} from 'react'
+import {Scrollama, Step} from 'react-scrollama'
 
-class Graphic extends Component {
-  state = {
-    data: 0,
-  };
-
-  onStepEnter = ({ data }) => this.setState({ data });
-
-  render() {
-    const { data } = this.state;
-
-    return (
-      <div>
-        <p style={{ position: 'sticky', top: 0 }}>data: {data}</p>
-        <Scrollama onStepEnter={this.onStepEnter} debug>
-          {[1, 2, 3, 4].map((d, i) => (
-            <Step data={d} key={i}>
-              <div style={{ margin: '50vh 0' }}>
-                <p>
-                  step index = {i}; data value = {d}
-                </p>
-              </div>
-            </Step>
-          ))}
-        </Scrollama>
-      </div>
-    );
+const ScrollamaDemo = () => {
+  const [currentStepIndex, setCurrentStepIndex] = useState(null)
+  
+  // When a Scrollama Step is triggered the callback receives its data prop, which in this demo stores the step index.
+  const onStepEnter = ({ data }) => {
+    setCurrentStepIndex(data) 
   }
+  
+  return (
+    <div style={{ margin: '50vh 0', border: '2px dashed skyblue' }}>
+      <div style={{ position: "sticky", top: 0, border: '1px dashed orchid' }}>
+        I'm sticky. The current triggered step index is: {currentStepIndex}
+      </div>
+      <Scrollama onStepEnter={onStepEnter} debug>
+        {[1, 2, 3, 4].map((_, stepIndex) => (
+          <Step data={stepIndex} key={stepIndex}>
+            <div style={{ margin: '50vh 0', border: '1px dashed gray', opacity: currentStepIndex === stepIndex ? 1 : 0.2 }}>
+              I'm a Scrollama Step of index {stepIndex}.
+            </div>
+          </Step>
+        ))}
+      </Scrollama>
+    </div>
+  )
 }
+
+export default ScrollamaDemo
 ```
 
 ## API


### PR DESCRIPTION
Jason, thanks for putting this library together! I've loved using it in projects.

After learning it myself, and teaching it to a friend, I noticed myself re-writing the no-frills demo to make it easier to understand/teach. I thought sharing the changes might make it easier for others to jump in.

Specifically:
1. I updated to modern, functional React with hooks.
2. There was a fair bit of confusion between `data` in `<Step data={} />` and `this.state.data` which made it hard to quickly see how lightweight and simple the API actually is.
3. I've simplified the HTML down to just a `div` wrapper around each part of the demo (container, sticky, steps) to help Scrollama shine through better.
4. Since the first thing most people do is copy and paste the demo from the README, I've added some light dashed borders and opacity toggling to make it super clear to see how intersections/sticky positioning is happening. While the opacity ternary may seem like a "frill," I actually think it shows a bare-bones example of why you'd use state in UI.

Again, thanks for making and open-sourcing this!