### PR TITLE
Quick-fix library could not initialise in componentDidMount 

### DIFF
--- a/src/Scrollama.js
+++ b/src/Scrollama.js
@@ -92,7 +92,7 @@ class Scrollama extends Component {
   }
 
   componentDidMount() {
-    window.addEventListener('load', this.domDidLoad.bind(this));
+    this.domDidLoad.bind(this)();
   }
 
   domDidLoad() {
@@ -167,7 +167,8 @@ class Scrollama extends Component {
     const { offsetMargin } = this.state;
     this.io.stepAbove = this.stepElIds.map(id => {
       const step = this.getStep(id);
-      const marginTop = -offsetMargin + step.state.offsetHeight;
+      const stepStateOffsetHeight = step.updateOffsetHeight();
+      const marginTop = -offsetMargin +  stepStateOffsetHeight; //step.state.offsetHeight;
       const marginBottom = offsetMargin - this.viewH;
       const options = {
         rootMargin: `${marginTop}px 0px ${marginBottom}px 0px`,
@@ -184,8 +185,9 @@ class Scrollama extends Component {
     const { offsetMargin } = this.state;
     this.io.stepBelow = this.stepElIds.map(id => {
       const step = this.getStep(id);
+      const stepStateOffsetHeight = step.updateOffsetHeight();
       const marginTop = -offsetMargin;
-      const marginBottom = offsetMargin - this.viewH + step.state.offsetHeight;
+      const marginBottom = offsetMargin - this.viewH + stepStateOffsetHeight; //step.state.offsetHeight;
       const options = {
         rootMargin: `${marginTop}px 0px ${marginBottom}px 0px`,
       };

--- a/src/Step.js
+++ b/src/Step.js
@@ -14,10 +14,13 @@ class Step extends Component {
 
   getData = () => this.props.data;
 
-  updateOffsetHeight = () =>
+  updateOffsetHeight = () =>{
+    const offsetHeight = this.getDOMNode().offsetHeight;
     this.setState({
-      offsetHeight: this.getDOMNode().offsetHeight,
+      offsetHeight,
     });
+    return offsetHeight;
+  }
 
   enter = direction => this.setState({ state: 'enter', direction });
   exit = direction => this.setState({ state: 'exit', direction });


### PR DESCRIPTION
I am creating this PR as draft because i believe there is a cleaner solution to the problem. I didn't have the time yet to dive deeper, but maybe its also clear to @jsonkao how to introduce the proper fix?!

Anyway this PR describes the problem and introduces a quick-fix to enable this desired initialisation on `componentDidMount`.

### Short description

Previously this library introduced a fix for #40 by initialising the lib upon `document.load`. As we found out this is not sufficient for any situation you want to use the lib past the `document.load`. To introduce a better usability we have to init in `componentDidMount`. @jsonkao stated that he experienced problems with this pattern. And I also could experience some problems with doing so. The problem is that somehow the component state (of each steps) is `undefined`  when `updateStepBelowIO` and `updateStepAboveIO` are called—although we are calling `updateOffsetHeight` before we initialise. I am not sure why this is the case but I believe it has to do with how the refs are resolved... @jsonkao maybe you have a clue.

The quick fix returns the current `offsetHeight` when `updateOffsetHeight` is called. And we call `updateOffsetHeight` before we init the `IntersectionObserver`'s. 