### PR TITLE
SSR fix

### DIFF
--- a/src/Scrollama.js
+++ b/src/Scrollama.js
@@ -27,7 +27,7 @@ class Scrollama extends Component {
   // stores step elements by id
   stepElIds = [];
 
-  viewH = typeof window !== undefined ? window.innerHeight : 0;
+  viewH = typeof window !== 'undefined' ? window.innerHeight : 0;
   pageH = 0;
   offsetVal = 0;
   offsetMargin = 0;


### PR DESCRIPTION
The previous commit to fix builds with server side rendering does not work correctly, as `typeof window` is equal to `"undefined"` instead of `undefined` when the window is not defined.