### PR TITLE
Default scroll direction Down

### DIFF
--- a/src/Step.js
+++ b/src/Step.js
@@ -29,7 +29,7 @@ const Step = props => {
 
   const isBrowser = typeof window !== "undefined";
   const scrollTop = isBrowser ? document.documentElement.scrollTop : 0;
-  const direction = lastScrollTop < scrollTop ? 'down' : 'up';
+  const direction = lastScrollTop > scrollTop ? 'up' : 'down';
 
   const rootMargin = useRootMargin(offset);
 


### PR DESCRIPTION
There is an edge case where if your step element is visible when `scrollTop` is 0, the scroll `direction` will be `up`. I.e. when you first load your page, the first scroll direction you'll see in `onStepEnter` will be `up`.

While admittedly an edge case, I think we should switch the logic so that the default scroll direction is `down`